### PR TITLE
fix: debounce rapid voice-mode toggles to avoid 429 rate-limit collisions

### DIFF
--- a/plugin/dsh-voice-mode/src/client.tsx
+++ b/plugin/dsh-voice-mode/src/client.tsx
@@ -1583,7 +1583,12 @@ export function MicButton({
     }
   }
 
+  /** 点击防抖：2 秒内重复的进/出请求只响应第一次（避免撞 /toggle 限流 429）。 */
+  const toggleGuardRef = useRef(0)
   const toggle = (): void => {
+    const now = Date.now()
+    if (now - toggleGuardRef.current < 2000) return
+    toggleGuardRef.current = now
     if (localRef.current === 'on') void exitModeRef.current('manual')
     else if (localRef.current === 'off') void enterMode()
   }
@@ -1948,6 +1953,10 @@ export function MicButton({
     }
     if (ms < 250) {
       // 短按：on → 退出语音模式（tap-to-exit）；off → 进入（hold 模式全程 pointer 驱动）
+      // 同受 2 秒点击防抖保护（快速连点只响应第一次）。
+      const now = Date.now()
+      if (now - toggleGuardRef.current < 2000) return
+      toggleGuardRef.current = now
       if (localRef.current === 'on') {
         engineRef.current?.endHeld(true)
         void exitModeRef.current('manual')

--- a/plugin/dsh-voice-mode/src/index.ts
+++ b/plugin/dsh-voice-mode/src/index.ts
@@ -619,8 +619,9 @@ export function apply(ctx: Context, config: Config): void {
             respondJson(res, 400, { error: 'invalid on' })
             return
           }
-          // fork 加固：切换限流（每会话 1 次/2 秒，防状态抖动攻击）。
-          if (!limiter.hit(`toggle:${sessionId}`, 1, 2000)) {
+          // fork 加固：切换限流（每会话 2 次/2 秒——允许「进+退」这类正常快速操作对；
+          // 客户端另有 2 秒点击防抖，双保险防状态抖动）。
+          if (!limiter.hit(`toggle:${sessionId}`, 2, 2000)) {
             res.statusCode = 429
             res.setHeader('content-type', 'application/json')
             res.end(JSON.stringify({ error: 'rate limited' }))


### PR DESCRIPTION
## 问题

快速点击麦克风按钮（或"打字自动退出 + 立刻重进"）时，多次 `/voice-mode/toggle` 落在每会话 1 次/2 秒的限流窗口内 → 429 → 语音模式开关状态错位，用户看到的现象是"点了没反应 / 进不去"。

## 修复（双保险）

1. **客户端 2 秒点击防抖**：`toggle()` 与 hold 模式的短按进入/退出路径统一加 2 秒守卫——2 秒内重复操作只响应第一次（键盘快捷键同样经 `toggle()` 覆盖）；
2. **host 限流放宽**：`/toggle` 从每会话 1 次/2 秒 → **2 次/2 秒**，允许"进+退"这类正常快速操作对（风暴依然被挡）。

## 验证

- 基于 v0.5.0（当前 main）基线移植；
- host + client 类型检查 0 错误。

改动范围：`src/client.tsx`（+9）、`src/index.ts`（+3/−2），共 12 行。
